### PR TITLE
Infrastructure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,8 @@
     <properties>
         <java.version>19</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <mavenBuiltTimestamp>${maven.build.timestamp}</mavenBuiltTimestamp>
+        <maven.build.timestamp.format>yyyy-MM-dd HH:mmZZ</maven.build.timestamp.format>
 
         <commons-lang3.version>3.13.0</commons-lang3.version>
     </properties>
@@ -64,8 +66,6 @@
         </dependency>
 
 
-
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -75,14 +75,37 @@
 
     <build>
         <plugins>
-
-
-
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <fork>true</fork>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>spring-boot</classifier>
+                            <mainClass>cj.software.genetics.schedule.server.GeneticSchedulingApplication</mainClass>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
 

--- a/src/main/java/cj/software/genetics/schedule/server/Constants.java
+++ b/src/main/java/cj/software/genetics/schedule/server/Constants.java
@@ -1,0 +1,6 @@
+package cj.software.genetics.schedule.server;
+
+@SuppressWarnings("java:S1214")     // this interface cannot be replaced by an enum
+public interface Constants {
+    String CORRELATION_ID_KEY = "correlation-id";
+}

--- a/src/main/java/cj/software/genetics/schedule/server/api/util/HttpHeadersManager.java
+++ b/src/main/java/cj/software/genetics/schedule/server/api/util/HttpHeadersManager.java
@@ -1,0 +1,103 @@
+package cj.software.genetics.schedule.server.api.util;
+
+import cj.software.genetics.schedule.server.Constants;
+import cj.software.genetics.schedule.server.entity.configuration.ConfigurationHolder;
+import cj.software.genetics.schedule.server.entity.configuration.GeneralConfiguration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+
+@WebFilter("/*")
+@Component
+public class HttpHeadersManager implements Filter {
+    private static final String[] HEADERS_TO_TRY = {
+            "X-Forwarded-For",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_X_FORWARDED_FOR",
+            "HTTP_X_FORWARDED",
+            "HTTP_X_CLUSTER_CLIENT_IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_FORWARDED_FOR",
+            "HTTP_FORWARDED",
+            "HTTP_VIA",
+            "REMOTE_ADDR"};
+
+    @Autowired
+    private ConfigurationHolder configurationHolder;
+
+    private final Logger logger = LogManager.getFormatterLogger();
+
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+        String oldCorrelationId = MDC.get(Constants.CORRELATION_ID_KEY);
+        try {
+            String correlationId = constructCorrelationId(httpServletRequest);
+            MDC.put(Constants.CORRELATION_ID_KEY, correlationId);
+            String requestDescription = describe(httpServletRequest);
+            logger.info("processing %s...", requestDescription);
+            HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
+            GeneralConfiguration generalConfiguration = configurationHolder.getGeneral();
+            httpServletResponse.addHeader("cj.software.backend-version", generalConfiguration.getBackendVersion());
+            httpServletResponse.addHeader("cj.software.backend-built", generalConfiguration.getBackendBuilt());
+            httpServletResponse.addHeader(Constants.CORRELATION_ID_KEY, correlationId);
+
+            filterChain.doFilter(servletRequest, servletResponse);
+
+        } finally {
+            MDC.put(Constants.CORRELATION_ID_KEY, oldCorrelationId);
+        }
+    }
+
+    private String constructCorrelationId(HttpServletRequest request) {
+        String existing = request.getHeader(Constants.CORRELATION_ID_KEY);
+        String result;
+        if (existing != null && !existing.isBlank()) {
+            result = existing;
+        } else {
+            result = UUID.randomUUID().toString();
+        }
+        return result;
+    }
+
+    private String describe(HttpServletRequest request) {
+        String remoteAddress = determineCaller(request);
+        StringBuilder sb = new StringBuilder()
+                .append(request.getMethod())
+                .append(" ")
+                .append(request.getRequestURI())
+                .append(" from ")
+                .append(remoteAddress);
+        String result = sb.toString();
+        return result;
+    }
+
+    private String determineCaller(HttpServletRequest request) {
+        String result = null;
+        for (String header : HEADERS_TO_TRY) {
+            result = request.getHeader(header);
+            if (result != null && !result.isBlank()) {
+                break;
+            }
+        }
+        if (result == null) {
+            result = request.getRemoteAddr();
+        }
+        return result;
+    }
+}

--- a/src/main/java/cj/software/genetics/schedule/server/entity/configuration/ConfigurationHolder.java
+++ b/src/main/java/cj/software/genetics/schedule/server/entity/configuration/ConfigurationHolder.java
@@ -1,0 +1,60 @@
+package cj.software.genetics.schedule.server.entity.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.io.Serial;
+import java.io.Serializable;
+
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "cj.software.genetics.server")
+@Validated
+@EnableAspectJAutoProxy
+public class ConfigurationHolder implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @NotNull
+    @Valid
+    private GeneralConfiguration general;
+
+    ConfigurationHolder() {
+    }
+
+    public GeneralConfiguration getGeneral() {
+        return general;
+    }
+
+    public void setGeneral(GeneralConfiguration general) {
+        this.general = general;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        protected ConfigurationHolder instance;
+
+        protected Builder() {
+            instance = new ConfigurationHolder();
+        }
+
+        public ConfigurationHolder build() {
+            ConfigurationHolder result = instance;
+            instance = null;
+            return result;
+        }
+
+        public Builder withGeneral(GeneralConfiguration general) {
+            instance.setGeneral(general);
+            return this;
+        }
+    }
+}

--- a/src/main/java/cj/software/genetics/schedule/server/entity/configuration/GeneralConfiguration.java
+++ b/src/main/java/cj/software/genetics/schedule/server/entity/configuration/GeneralConfiguration.java
@@ -1,0 +1,63 @@
+package cj.software.genetics.schedule.server.entity.configuration;
+
+import javax.validation.constraints.NotBlank;
+import java.io.Serial;
+import java.io.Serializable;
+
+public class GeneralConfiguration implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @NotBlank
+    private String backendVersion;
+
+    @NotBlank
+    private String backendBuilt;
+
+    private GeneralConfiguration() {
+    }
+
+    public String getBackendVersion() {
+        return backendVersion;
+    }
+
+    public void setBackendVersion(String backendVersion) {
+        this.backendVersion = backendVersion;
+    }
+
+    public String getBackendBuilt() {
+        return backendBuilt;
+    }
+
+    public void setBackendBuilt(String backendBuilt) {
+        this.backendBuilt = backendBuilt;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        protected GeneralConfiguration instance;
+
+        protected Builder() {
+            instance = new GeneralConfiguration();
+        }
+
+        public GeneralConfiguration build() {
+            GeneralConfiguration result = instance;
+            instance = null;
+            return result;
+        }
+
+        public Builder withBackendVersion(String backendVersion) {
+            instance.setBackendVersion(backendVersion);
+            return this;
+        }
+
+        public Builder withBackendBuilt(String backendBuilt) {
+            instance.setBackendBuilt(backendBuilt);
+            return this;
+        }
+    }
+}

--- a/src/main/java/cj/software/genetics/schedule/server/util/ConfigurationDumper.java
+++ b/src/main/java/cj/software/genetics/schedule/server/util/ConfigurationDumper.java
@@ -1,0 +1,43 @@
+package cj.software.genetics.schedule.server.util;
+
+import cj.software.genetics.schedule.server.Constants;
+import cj.software.genetics.schedule.server.entity.configuration.ConfigurationHolder;
+import cj.software.genetics.schedule.server.entity.configuration.GeneralConfiguration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConfigurationDumper implements InitializingBean {
+
+    private static final String STRING_FORMAT = "%50.50s = %s";
+
+    private static final String INT_FORMAT = "%50.50s = %d";
+
+    @SuppressWarnings("java:S3749") // for Loggers OK
+    private final Logger logger = LogManager.getFormatterLogger();
+
+    @Autowired
+    private ConfigurationHolder configurationHolder;
+
+    @Override
+    public void afterPropertiesSet() {
+        try (MDC.MDCCloseable ignored = MDC.putCloseable(Constants.CORRELATION_ID_KEY, "config")) {
+            logger.info("##############################################################################");
+            logger.info("#####     List of all properties                                         #####");
+            logger.info("#####                                                                    #####");
+            logger.info("+++       General configuration                                            +++");
+            log(configurationHolder.getGeneral());
+            logger.info(INT_FORMAT, "The answer to all", 42);
+            logger.info("##############################################################################");
+        }
+    }
+
+    private void log(GeneralConfiguration configuration) {
+        logger.info(STRING_FORMAT, "backend version", configuration.getBackendVersion());
+        logger.info(STRING_FORMAT, "backend built", configuration.getBackendBuilt());
+    }
+}

--- a/src/main/java/cj/software/genetics/schedule/server/util/RandomService.java
+++ b/src/main/java/cj/software/genetics/schedule/server/util/RandomService.java
@@ -1,5 +1,6 @@
 package cj.software.genetics.schedule.server.util;
 
+import cj.software.util.spring.Trace;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
@@ -9,7 +10,8 @@ public class RandomService {
 
     private final SecureRandom secureRandom = new SecureRandom();
 
-    public int nextInt(int bound) {
+    @Trace
+    public int nextInt(@Trace int bound) {
         int result = secureRandom.nextInt(bound);
         return result;
     }

--- a/src/main/java/cj/software/genetics/schedule/server/util/SolutionService.java
+++ b/src/main/java/cj/software/genetics/schedule/server/util/SolutionService.java
@@ -6,7 +6,10 @@ import cj.software.genetics.schedule.server.api.entity.Solution;
 import cj.software.genetics.schedule.server.api.entity.Task;
 import cj.software.genetics.schedule.server.api.entity.Worker;
 import cj.software.genetics.schedule.server.exception.SlotOccupiedException;
+import cj.software.util.spring.Trace;
 import org.apache.commons.lang3.builder.CompareToBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +29,8 @@ public class SolutionService {
 
     @Autowired
     private TaskService taskService;
+
+    private final Logger logger = LogManager.getFormatterLogger();
 
     public Solution distribute(Solution source, SchedulingProblem schedulingProblem) throws SlotOccupiedException {
         Solution result = source;
@@ -51,7 +56,7 @@ public class SolutionService {
         return result;
     }
 
-    public Solution calculateFitnessValue(Solution solution) {
+    public Solution calculateFitnessValue(@Trace Solution solution) {
         Solution result = solution;
         long max = -1L;
         List<Worker> workers = solution.getWorkers();
@@ -59,8 +64,10 @@ public class SolutionService {
         for (Long duration : workerDurations) {
             max = Math.max(max, duration);
         }
+        logger.info("max duration  = %12d", max);
         double fitness = 1.0 / max;
         result.setFitnessValue(fitness);
+        logger.info("fitness value = %.12f", fitness);
         return result;
     }
 

--- a/src/main/java/cj/software/util/spring/MethodDescriptionGenerator.java
+++ b/src/main/java/cj/software/util/spring/MethodDescriptionGenerator.java
@@ -1,0 +1,98 @@
+package cj.software.util.spring;
+
+import org.apache.logging.log4j.spi.StandardLevel;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.SortedSet;
+
+@Service
+@TraceAtLogLevel(level = StandardLevel.TRACE)
+public class MethodDescriptionGenerator {
+    /**
+     * generates a description of a method entry. This description contains the name of the class and the name of the
+     * method. If the {@link List} parameterIndexesToBeReported is not empty, each entry of this {@link List} is used
+     * to obtain the indexed parameter name and value and add that to the description.<br/>
+     * Example:
+     * <ul>
+     *     <li>class name = {@code MyClass}</li>
+     *     <li>method name = {@code myMethod}</li>
+     *     <li>parameter names = {@code {"one", "two", "three"}}</li>
+     *     <li>parameter values = {@code {1, "Hello", false}}</li>
+     *     <li>indexes of parameters to be reported = {@code {1}}</li>
+     * </ul>
+     * In that case, the result would be <pre>
+     *     {@code MyClass.myMethod(two=Hello)}
+     * </pre>
+     *
+     * @param method                       the method to be reported
+     * @param parameterNames               names of the parameters
+     * @param parameterValues              values of the parameter
+     * @param parameterIndexesToBeReported indexes for parameter for which the (name, value) pair has to be added to
+     *                                     the result
+     * @return description of the method entry
+     */
+    public String generateMethodEntry(
+            Method method,
+            String[] parameterNames,
+            Object[] parameterValues,
+            @SuppressWarnings("java:S3242") // I really want to have it as a SortedSet
+            SortedSet<Integer> parameterIndexesToBeReported) {
+        StringBuilder sb = methodBegin(method);
+        if (!parameterIndexesToBeReported.isEmpty()) {
+            for (int index : parameterIndexesToBeReported) {
+                String parameterName = parameterNames[index];
+                Object parameterValue = parameterValues[index];
+                String formatted = String.format("%s=%s,", parameterName, parameterValue);
+                sb.append(formatted);
+            }
+            int length = sb.length();
+            sb.deleteCharAt(length - 1);
+        }
+        sb.append(")");
+        String result = sb.toString();
+        return result;
+    }
+
+    private StringBuilder methodBegin(Method method) {
+        String methodName = method.getName();
+        String className = method.getDeclaringClass().getSimpleName();
+        StringBuilder result = new StringBuilder(className).append(".").append(methodName);
+        result.append("(");
+        return result;
+    }
+
+    /**
+     * generates a description of a method return without the returned value
+     *
+     * @param method the method to be described
+     * @return the generated description
+     */
+    public String generateMethodExit(Method method) {
+        StringBuilder sb = methodBegin(method);
+        sb.append(")");
+        return sb.toString();
+    }
+
+    /**
+     * generate a description of a method together with the returned value
+     *
+     * @param method      the method to be described
+     * @param returnValue the value returned by the method
+     * @return the generated description
+     */
+    public String generateMethodExit(Method method, Object returnValue) {
+        StringBuilder sb = methodBegin(method);
+        sb.append(") returns ");
+        String formatted = String.format("%s", returnValue);
+        sb.append(formatted);
+        return sb.toString();
+    }
+
+    public String generateMethodThrew(Method method, Throwable throwable) {
+        StringBuilder sb = methodBegin(method);
+        sb.append(")").append(" threw ").append(throwable.getClass().getSimpleName());
+        return sb.toString();
+    }
+}

--- a/src/main/java/cj/software/util/spring/Trace.java
+++ b/src/main/java/cj/software/util/spring/Trace.java
@@ -1,0 +1,41 @@
+package cj.software.util.spring;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * marks whether a value participating in a method invocation should be traced by the {@link TraceAspect}. If we have
+ * a Java class {@code MyClass} with a method like that:
+ * <pre>
+ * {@code
+ * public @Trace String doSomething (
+ *     @Trace String param1,
+ *     String param2) {
+ *         // ...
+ *     }
+ * }
+ * </pre>
+ * <p>
+ * and some other Java method would invoke
+ * <pre>
+ *     {@code
+ *     myClass.doSomething("value1", "value2");
+ *     }
+ * </pre>
+ * <p>
+ * and the MyClass implementation would return the String {@code "VALUE1VALUE2"}
+ * <p>
+ * then the {@link TraceAspect} would produce an entries like that:
+ * <pre>
+ *     {@code
+ *     >MyClass.doSomething(param1=value1)
+ *     <MyClass.doSomething(..) returns VALUE1VALUE2
+ *     }
+ * </pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.CONSTRUCTOR})
+public @interface Trace {
+}

--- a/src/main/java/cj/software/util/spring/TraceAspect.java
+++ b/src/main/java/cj/software/util/spring/TraceAspect.java
@@ -1,0 +1,209 @@
+package cj.software.util.spring;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * an aspect that automatically generates trace lines in the logging. For each method entry, a short description
+ * of the method name is logged with a right pointing arrow head at the beginning. After that log line, all log lines
+ * are indented by a couple of blanks. When the method returns, a similar description is logged with a left pointing
+ * arrow head at the beginning, and the indentation is reduced. With that behaviour, it can easily be determined in
+ * which method an own log entry was produced, and which method was invoked from which other method.
+ * <br/>
+ * Imagine you have a class like that:
+ * <pre>
+ *     {@code
+ *     @Service
+ *     public class OuterClass {
+ *         private Logger logger = LogManager.getFormatterLogger();
+ *
+ *         @Autowired
+ *         InnerClass innerClass;
+ *
+ *         public void method1() {
+ *             logger.info("custom log entry 1");
+ *             innerClass.method2();
+ *         }
+ *     }
+ *     }
+ * </pre>
+ * <p>
+ * and a class like that:
+ * <pre>
+ *     {@code
+ *     @Service
+ *     public class InnerClass {
+ *         private Logger logger = LogManager.getFormatterLogger();
+ *         public void method2() {
+ *             logger.info("log entry from inner class");
+ *         }
+ *     }
+ *     }
+ * </pre>
+ * <p>
+ * then the logs would look like that:
+ * <pre>
+ *     &gt;OuterClass.method1()
+ *         custom log entry 1
+ *         &gt; InnerClass.method2()
+ *             log entry from inner class
+ *         &lt; InnerClass.method2()
+ *     &lt;OuterClass.method1()
+ * </pre>
+ */
+@Component
+@Aspect
+@Order(0)
+public class TraceAspect {
+    private static final String KEY = "indent";
+    private static final String INDENT = "    ";
+
+    @Autowired
+    private MethodDescriptionGenerator descriptionGenerator;
+
+    @Pointcut("execution(* cj.software.genetics.schedule..*.*(..)) && ! within(TraceAspect)")
+    public void eonMethod() {
+        // pointcuts are empty
+    }
+
+    @Pointcut("execution(* cj.software..entity..*.*(..))")
+    public void entity() {
+        // pointcuts are empty
+    }
+
+    @Pointcut("execution(* cj.software..*.get*())")
+    public void objectGetter() {
+        // pointcuts are empty
+    }
+
+    @Pointcut("execution(boolean cj.software..*.is*())")
+    public void booleanGetter() {
+        // pointcuts are empty
+    }
+
+    @Pointcut("eonMethod() && ! entity() && ! objectGetter() && ! booleanGetter()")
+    public void toBeTraced() {
+        // pointcuts are empty
+    }
+
+    @Pointcut("@annotation(cj.software.util.spring.Trace)")
+    public void annotatedMethod() {
+        // any method that has this annotation
+    }
+
+    @Before("toBeTraced()")
+    public void reportMethodEntry(JoinPoint joinPoint) {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        Method method = methodSignature.getMethod();
+        Class<?> declaringType = methodSignature.getDeclaringType();
+        Logger logger = LogManager.getFormatterLogger(declaringType);
+        if (canLog(method, logger)) {
+            Object[] args = joinPoint.getArgs();
+            String[] parameterNames = methodSignature.getParameterNames();
+            SortedSet<Integer> indexes = determineIndexesOfLoggedParameters(methodSignature);
+            String description = descriptionGenerator.generateMethodEntry(method, parameterNames, args, indexes);
+            logger.info(">%s", description);
+        }
+        String indentValue = MDC.get(KEY);
+        if (indentValue == null) {
+            indentValue = "";
+        }
+        indentValue = String.format("%s%s", INDENT, indentValue);
+        MDC.put(KEY, indentValue);
+    }
+
+    private boolean canLog(Method method, Logger logger) {
+        TraceAtLogLevel traceAtLogLevel = method.getAnnotation(TraceAtLogLevel.class);
+        if (traceAtLogLevel == null) {
+            Class<?> clazz = method.getDeclaringClass();
+            traceAtLogLevel = clazz.getAnnotation(TraceAtLogLevel.class);
+        }
+        int requiredLevel = (traceAtLogLevel != null ? traceAtLogLevel.level().intLevel() : Level.INFO.intLevel());
+        int loggerLevel = logger.getLevel().intLevel();
+        boolean result = (loggerLevel >= requiredLevel);
+        return result;
+    }
+
+    @AfterReturning(value = "toBeTraced() && annotatedMethod()", returning = "result")
+    public void reportMethodReturnWithResult(JoinPoint joinPoint, Object result) {
+        decreaseIndent();
+        MethodSignature sig = (MethodSignature) joinPoint.getSignature();
+        Method method = sig.getMethod();
+        Class<?> declaringType = sig.getDeclaringType();
+        Logger logger = LogManager.getFormatterLogger(declaringType);
+        if (canLog(method, logger)) {
+            String description = descriptionGenerator.generateMethodExit(method, result);
+            logger.info("<%s", description);
+        }
+    }
+
+    private void decreaseIndent() {
+        String indentValue = MDC.get(KEY);
+        if (indentValue != null && !indentValue.isEmpty()) {
+            indentValue = indentValue.substring(INDENT.length());
+            MDC.put(KEY, indentValue);
+        }
+    }
+
+    @AfterReturning("toBeTraced() && ! annotatedMethod()")
+    public void reportMethodReturnWithoutResult(JoinPoint joinPoint) {
+        decreaseIndent();
+        MethodSignature sig = (MethodSignature) joinPoint.getSignature();
+        Class<?> declaringType = sig.getDeclaringType();
+        Logger logger = LogManager.getFormatterLogger(declaringType);
+        Method method = sig.getMethod();
+        if (canLog(method, logger)) {
+            String description = descriptionGenerator.generateMethodExit(method);
+            logger.info("<%s", description);
+        }
+    }
+
+    @AfterThrowing(value = "toBeTraced()", throwing = "throwable")
+    public void reportMethodReturnWithException(JoinPoint joinPoint, Throwable throwable) {
+        decreaseIndent();
+        MethodSignature sig = (MethodSignature) joinPoint.getSignature();
+        Class<?> declaringType = sig.getDeclaringType();
+        Logger logger = LogManager.getFormatterLogger(declaringType);
+        Method method = sig.getMethod();
+        if (canLog(method, logger)) {
+            String description = descriptionGenerator.generateMethodThrew(method, throwable);
+            logger.error("<%s", description);
+        }
+
+    }
+
+    private SortedSet<Integer> determineIndexesOfLoggedParameters(MethodSignature methodSignature) {
+        SortedSet<Integer> result = new TreeSet<>();
+        Method method = methodSignature.getMethod();
+        Annotation[][] annotations = method.getParameterAnnotations();
+        int outerCount = annotations.length;
+        for (int outer = 0; outer < outerCount; outer++) {
+            Annotation[] innerAnnotations = annotations[outer];
+            for (Annotation innerAnnotation : innerAnnotations) {
+                Class<?> annoClass = innerAnnotation.annotationType();
+                if (annoClass.isAssignableFrom(Trace.class)) {
+                    result.add(outer);
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/cj/software/util/spring/TraceAtLogLevel.java
+++ b/src/main/java/cj/software/util/spring/TraceAtLogLevel.java
@@ -1,0 +1,43 @@
+package cj.software.util.spring;
+
+import org.apache.logging.log4j.spi.StandardLevel;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * controls the log level for the automatic tracing of the {@link TraceAspect}. If a class for example has this setting:
+ * <pre>
+ *     {@code
+ *     @TraceAtLogLevel(level = StandardLevel.DEBUG)
+ *     public class MyClass {
+ *         public void myMethod() {
+ *
+ *         }
+ *     }}
+ * </pre>
+ * then the method entry and exit will only be traced if the logger for that class has at least debug level.
+ * <p>
+ * Watch out when using this annotation. If your method issues its own log entry, this one will be indented, but
+ * it will be embedded of the method description of the invoker of your method like this:
+ * <pre>
+ *         {@code
+ *         >OuterOuterClass.outeroutermethod()
+ *             >OuterClass.outermethod()
+ *                log entry from outermethod
+ *                >YourClass.yourMethod()
+ *                    log entry from your method
+ *                <YourClass.yourMethod
+ *                another log entry from outermethod
+ *             <OuterClass.outermethod()
+ *          <OuterOuterClass.outeroutermethod()
+ *         }
+ *     </pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
+public @interface TraceAtLogLevel {
+    StandardLevel level();
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+cj.software.genetics.server:
+  general:
+    backend-version: '@pom.version@'
+    backend-built: '@mavenBuiltTimestamp@'

--- a/src/test/java/cj/software/genetics/schedule/server/entity/configuration/ConfigurationHolderBuilder.java
+++ b/src/test/java/cj/software/genetics/schedule/server/entity/configuration/ConfigurationHolderBuilder.java
@@ -1,0 +1,7 @@
+package cj.software.genetics.schedule.server.entity.configuration;
+
+public class ConfigurationHolderBuilder extends ConfigurationHolder.Builder {
+    public ConfigurationHolderBuilder() {
+        super.withGeneral(new GeneralConfigurationBuilder().build());
+    }
+}

--- a/src/test/java/cj/software/genetics/schedule/server/entity/configuration/ConfigurationHolderTest.java
+++ b/src/test/java/cj/software/genetics/schedule/server/entity/configuration/ConfigurationHolderTest.java
@@ -1,0 +1,88 @@
+package cj.software.genetics.schedule.server.entity.configuration;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigurationHolderTest {
+
+    @Test
+    void implementsSerializable() {
+        Class<?>[] interfaces = ConfigurationHolder.class.getInterfaces();
+        assertThat(interfaces).as("interfaces").contains(Serializable.class);
+    }
+
+    @Test
+    void metadata() {
+        Configuration configuration = ConfigurationHolder.class.getAnnotation(Configuration.class);
+        EnableConfigurationProperties enableConfigurationProperties = ConfigurationHolder.class.getAnnotation(EnableConfigurationProperties.class);
+        ConfigurationProperties configurationProperties = ConfigurationHolder.class.getAnnotation(ConfigurationProperties.class);
+        Validated validated = ConfigurationHolder.class.getAnnotation(Validated.class);
+        EnableAspectJAutoProxy enableAspectJAutoProxy = ConfigurationHolder.class.getAnnotation(EnableAspectJAutoProxy.class);
+
+        SoftAssertions softy = new SoftAssertions();
+        softy.assertThat(configuration).as("@Configuration").isNotNull();
+        softy.assertThat(enableConfigurationProperties).as("@EnableConfigurationProperties").isNotNull();
+        softy.assertThat(configurationProperties).as("@ConfigurationProperties").isNotNull();
+        softy.assertThat(validated).as("@Validated").isNotNull();
+        softy.assertThat(enableAspectJAutoProxy).as("@EnableAspectJAutoProxy").isNotNull();
+        softy.assertAll();
+    }
+
+    @Test
+    void constructEmpty()
+            throws NoSuchFieldException,
+            SecurityException,
+            IllegalArgumentException,
+            IllegalAccessException {
+        ConfigurationHolder.Builder builder = ConfigurationHolder.builder();
+        assertThat(builder).as("builder").isNotNull();
+
+        Field field = builder.getClass().getDeclaredField("instance");
+
+        Object instanceBefore = field.get(builder);
+        assertThat(instanceBefore).as("instance in builder before build").isNotNull().isInstanceOf(
+                ConfigurationHolder.class);
+
+        ConfigurationHolder instance = builder.build();
+        assertThat(instance).as("built instance").isNotNull();
+
+        Object instanceAfter = field.get(builder);
+        assertThat(instanceAfter).as("instance in builder after build").isNull();
+        assertThat(instance.getGeneral()).as("general").isNull();
+    }
+
+    @Test
+    void constructFilled() {
+        GeneralConfiguration general = GeneralConfiguration.builder().build();
+        ConfigurationHolder instance = ConfigurationHolder.builder()
+                .withGeneral(general)
+                .build();
+        assertThat(instance).as("built instance").isNotNull();
+        assertThat(instance.getGeneral()).as("general").isSameAs(general);
+    }
+
+    @Test
+    void defaultIsValid() {
+        ConfigurationHolder instance = new ConfigurationHolderBuilder().build();
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            Set<ConstraintViolation<ConfigurationHolder>> violations = validator.validate(instance);
+            assertThat(violations).as("constraint violations").isEmpty();
+        }
+    }
+}

--- a/src/test/java/cj/software/genetics/schedule/server/entity/configuration/ConfigurationHolderTestConfiguration.java
+++ b/src/test/java/cj/software/genetics/schedule/server/entity/configuration/ConfigurationHolderTestConfiguration.java
@@ -1,0 +1,13 @@
+package cj.software.genetics.schedule.server.entity.configuration;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class ConfigurationHolderTestConfiguration {
+    @Bean("configurationHolder")
+    public ConfigurationHolder configurationHolder() {
+        ConfigurationHolder result = new ConfigurationHolderBuilder().build();
+        return result;
+    }
+}

--- a/src/test/java/cj/software/genetics/schedule/server/entity/configuration/GeneralConfigurationBuilder.java
+++ b/src/test/java/cj/software/genetics/schedule/server/entity/configuration/GeneralConfigurationBuilder.java
@@ -1,0 +1,8 @@
+package cj.software.genetics.schedule.server.entity.configuration;
+
+public class GeneralConfigurationBuilder extends GeneralConfiguration.Builder {
+    public GeneralConfigurationBuilder() {
+        super.withBackendVersion("1.23")
+                .withBackendBuilt("2023-11-15T13:14:15+01:00");
+    }
+}

--- a/src/test/java/cj/software/genetics/schedule/server/entity/configuration/GeneralConfigurationTest.java
+++ b/src/test/java/cj/software/genetics/schedule/server/entity/configuration/GeneralConfigurationTest.java
@@ -1,0 +1,74 @@
+package cj.software.genetics.schedule.server.entity.configuration;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GeneralConfigurationTest {
+
+    @Test
+    void implementsSerializable() {
+        Class<?>[] interfaces = GeneralConfiguration.class.getInterfaces();
+        assertThat(interfaces).as("interfaces").contains(Serializable.class);
+    }
+
+    @Test
+    void constructEmpty()
+            throws NoSuchFieldException,
+            SecurityException,
+            IllegalArgumentException,
+            IllegalAccessException {
+        GeneralConfiguration.Builder builder = GeneralConfiguration.builder();
+        assertThat(builder).as("builder").isNotNull();
+
+        Field field = builder.getClass().getDeclaredField("instance");
+
+        Object instanceBefore = field.get(builder);
+        assertThat(instanceBefore).as("instance in builder before build").isNotNull().isInstanceOf(
+                GeneralConfiguration.class);
+
+        GeneralConfiguration instance = builder.build();
+        assertThat(instance).as("built instance").isNotNull();
+
+        Object instanceAfter = field.get(builder);
+        assertThat(instanceAfter).as("instance in builder after build").isNull();
+        SoftAssertions softy = new SoftAssertions();
+        softy.assertThat(instance.getBackendVersion()).as("backend version").isNull();
+        softy.assertThat(instance.getBackendBuilt()).as("backend built").isNull();
+        softy.assertAll();
+    }
+
+    @Test
+    void constructFilled() {
+        String backendVersion = "_backendVersion";
+        String backendBuilt = "_backendBuilt";
+        GeneralConfiguration instance = GeneralConfiguration.builder()
+                .withBackendVersion(backendVersion)
+                .withBackendBuilt(backendBuilt)
+                .build();
+        assertThat(instance).as("built instance").isNotNull();
+        SoftAssertions softy = new SoftAssertions();
+        softy.assertThat(instance.getBackendVersion()).as("backend version").isEqualTo(backendVersion);
+        softy.assertThat(instance.getBackendBuilt()).as("backend built").isEqualTo(backendBuilt);
+        softy.assertAll();
+    }
+
+    @Test
+    void defaultIsValid() {
+        GeneralConfiguration instance = new GeneralConfigurationBuilder().build();
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            Set<ConstraintViolation<GeneralConfiguration>> violations = validator.validate(instance);
+            assertThat(violations).as("constraint violations").isEmpty();
+        }
+    }
+}

--- a/src/test/java/cj/software/genetics/schedule/server/util/ConfigurationDumperTest.java
+++ b/src/test/java/cj/software/genetics/schedule/server/util/ConfigurationDumperTest.java
@@ -1,0 +1,27 @@
+package cj.software.genetics.schedule.server.util;
+
+import cj.software.genetics.schedule.server.entity.configuration.ConfigurationHolderTestConfiguration;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = ConfigurationDumper.class)
+@Import(ConfigurationHolderTestConfiguration.class)
+class ConfigurationDumperTest {
+
+    @Test
+    void metadata() {
+        Component component = ConfigurationDumper.class.getAnnotation(Component.class);
+        Class<?>[] interfaces = ConfigurationDumper.class.getInterfaces();
+        SoftAssertions softy = new SoftAssertions();
+        softy.assertThat(component).as("@Component").isNotNull();
+        softy.assertThat(interfaces).as("interfaces").contains(InitializingBean.class);
+        softy.assertAll();
+    }
+}


### PR DESCRIPTION
add automatic handling of correlation ids. If the request has a header named `correlation-id`, then this one is taken. Otherwise, a UUID is generated as the correlation id. The response has a header `correlation-id` which reports the used correlation id.

Additionally, the response has headers with information about the built version and timestamp when it was built.

With AspectJ an automatic tracing procedure was implemented. With this, the control flow of the application can be examined in case of an error